### PR TITLE
Handle location query

### DIFF
--- a/test/RelativeLink-test.js
+++ b/test/RelativeLink-test.js
@@ -10,123 +10,126 @@ Link.BaseComponent = IndexLink.BaseComponent = () => null; // Use a dummy base c
 ["RelativeLink", "RelativeIndexLink"].forEach( (linkType) => {
     const Component = linkType === "RelativeLink" ? Link : IndexLink;
 
-    describe(linkType, function() {
-        describe("when the current path is `/zoo`", function() {
-            beforeEach(() => {
-                this.baseLinkSpy = sinon.spy(Component, "BaseComponent");
-                this.currentPath = "/zoo";
-            });
-            afterEach(() => {
-                this.baseLinkSpy.restore();
-            });
-            it("should call the base Link once when rendered", () => {
-                mount(<Component currentPath={this.currentPath} to="lions" />);
-                expect(this.baseLinkSpy.calledOnce).to.equal(true);
-            });
-            it("should not pass `currentPath` to the base Link", () => {
-                mount(<Component currentPath={this.currentPath} to="lions" />);
-                const props = this.baseLinkSpy.getCall(0).args[0];
-                expect(props.currentPath).to.equal(undefined);
-            });
-            it("resolves to `/zoo/lions` when given `lions`", () => {
-                mount(<Component currentPath={this.currentPath} to="lions" />);
-                const props = this.baseLinkSpy.getCall(0).args[0];
-                expect(props.to).to.equal("/zoo/lions");
-            });
-            it("resolves to `/zoo/lions` when given `./lions`", () => {
-                mount(<Component currentPath={this.currentPath} to="./lions" />);
-                const props = this.baseLinkSpy.getCall(0).args[0];
-                expect(props.to).to.equal("/zoo/lions");
-            });
-            it("resolves to `/` when given `/`", () => {
-                mount(<Component currentPath={this.currentPath} to="/" />);
-                const props = this.baseLinkSpy.getCall(0).args[0];
-                expect(props.to).to.equal("/");
-            });
-            it("resolves to `/bar` when given `/bar`", () => {
-                mount(<Component currentPath={this.currentPath} to="/bar" />);
-                const props = this.baseLinkSpy.getCall(0).args[0];
-                expect(props.to).to.equal("/bar");
-            });
-        });
+    ["", "?beast=yes"].forEach((queryString) => {
 
-        describe("when the current path is `/zoo/lions`", function() {
-            beforeEach(() => {
-                this.baseLinkSpy = sinon.spy(Component, "BaseComponent");
-                this.currentPath = "/zoo/lions";
+        describe(linkType, function() {
+            describe(`when the current path is "/zoo${queryString}"`, function() {
+                beforeEach(() => {
+                    this.baseLinkSpy = sinon.spy(Component, "BaseComponent");
+                    this.currentPath = `/zoo${queryString}`;
+                });
+                afterEach(() => {
+                    this.baseLinkSpy.restore();
+                });
+                it("should call the base Link once when rendered", () => {
+                    mount(<Component currentPath={this.currentPath} to="lions" />);
+                    expect(this.baseLinkSpy.calledOnce).to.equal(true);
+                });
+                it("should not pass `currentPath` to the base Link", () => {
+                    mount(<Component currentPath={this.currentPath} to="lions" />);
+                    const props = this.baseLinkSpy.getCall(0).args[0];
+                    expect(props.currentPath).to.equal(undefined);
+                });
+                it(`resolves to "/zoo/lions${queryString}" when given "lions"`, () => {
+                    mount(<Component currentPath={this.currentPath} to="lions" />);
+                    const props = this.baseLinkSpy.getCall(0).args[0];
+                    expect(props.to).to.equal(`/zoo/lions${queryString}`);
+                });
+                it(`resolves to "/zoo/lions${queryString}" when given "./lions"`, () => {
+                    mount(<Component currentPath={this.currentPath} to="./lions" />);
+                    const props = this.baseLinkSpy.getCall(0).args[0];
+                    expect(props.to).to.equal(`/zoo/lions${queryString}`);
+                });
+                it(`resolves to "/${queryString}" when given "/"`, () => {
+                    mount(<Component currentPath={this.currentPath} to="/" />);
+                    const props = this.baseLinkSpy.getCall(0).args[0];
+                    expect(props.to).to.equal(`/${queryString}`);
+                });
+                it(`resolves to "/bar${queryString}" when given "/bar"`, () => {
+                    mount(<Component currentPath={this.currentPath} to="/bar" />);
+                    const props = this.baseLinkSpy.getCall(0).args[0];
+                    expect(props.to).to.equal(`/bar${queryString}`);
+                });
             });
-            afterEach(() => {
-                this.baseLinkSpy.restore();
-            });
-            it("resolves to `/zoo/giraffes` when given `../giraffes`", () => {
-                mount(<Component currentPath={this.currentPath} to="../giraffes" />);
-                const props = this.baseLinkSpy.getCall(0).args[0];
-                expect(props.to).to.equal("/zoo/giraffes");
-            });
-            it("resolves to `/zoo/lions/mountain` when given `../giraffes`", () => {
-                mount(<Component currentPath={this.currentPath} to="mountain" />);
-                const props = this.baseLinkSpy.getCall(0).args[0];
-                expect(props.to).to.equal("/zoo/lions/mountain");
-            });
-        });
 
-        describe("when the current path is `/`", function() {
-            beforeEach(() => {
-                this.baseLinkSpy = sinon.spy(Component, "BaseComponent");
-                this.currentPath = "/";
+            describe(`when the current path is "/zoo/lions${queryString}"`, function() {
+                beforeEach(() => {
+                    this.baseLinkSpy = sinon.spy(Component, "BaseComponent");
+                    this.currentPath = `/zoo/lions${queryString}`;
+                });
+                afterEach(() => {
+                    this.baseLinkSpy.restore();
+                });
+                it(`resolves to "/zoo/giraffes${queryString}" when given "../giraffes"`, () => {
+                    mount(<Component currentPath={this.currentPath} to="../giraffes" />);
+                    const props = this.baseLinkSpy.getCall(0).args[0];
+                    expect(props.to).to.equal(`/zoo/giraffes${queryString}`);
+                });
+                it(`resolves to "/zoo/lions/mountain${queryString}" when given "../giraffes"`, () => {
+                    mount(<Component currentPath={this.currentPath} to="mountain" />);
+                    const props = this.baseLinkSpy.getCall(0).args[0];
+                    expect(props.to).to.equal(`/zoo/lions/mountain${queryString}`);
+                });
             });
-            afterEach(() => {
-                this.baseLinkSpy.restore();
-            });
-            it("resolves to `/zoo` when given `zoo`", () => {
-                mount(<Component currentPath={this.currentPath} to="zoo" />);
-                const props = this.baseLinkSpy.getCall(0).args[0];
-                expect(props.to).to.equal("/zoo");
-            });
-            it("resolves to `/zoo` when given `/zoo`", () => {
-                mount(<Component currentPath={this.currentPath} to="/zoo" />);
-                const props = this.baseLinkSpy.getCall(0).args[0];
-                expect(props.to).to.equal("/zoo");
-            });
-            it("resolves to `/zoo` when given `/zoo/`", () => {
-                mount(<Component currentPath={this.currentPath} to="/zoo/" />);
-                const props = this.baseLinkSpy.getCall(0).args[0];
-                expect(props.to).to.equal("/zoo");
-            });
-            it("resolves to `/zoo` when given `zoo/`", () => {
-                mount(<Component currentPath={this.currentPath} to="zoo/" />);
-                const props = this.baseLinkSpy.getCall(0).args[0];
-                expect(props.to).to.equal("/zoo");
-            });
-        });
 
-        describe("when the current path is not specified", function() {
-            beforeEach(() => {
-                this.baseLinkSpy = sinon.spy(Component, "BaseComponent");
-                global.location.hash = "#/foo";
+            describe(`when the current path is "/${queryString}"`, function() {
+                beforeEach(() => {
+                    this.baseLinkSpy = sinon.spy(Component, "BaseComponent");
+                    this.currentPath = `/${queryString}`;
+                });
+                afterEach(() => {
+                    this.baseLinkSpy.restore();
+                });
+                it(`resolves to "/zoo${queryString}" when given "zoo"`, () => {
+                    mount(<Component currentPath={this.currentPath} to="zoo" />);
+                    const props = this.baseLinkSpy.getCall(0).args[0];
+                    expect(props.to).to.equal(`/zoo${queryString}`);
+                });
+                it(`resolves to "/zoo${queryString}" when given "/zoo"`, () => {
+                    mount(<Component currentPath={this.currentPath} to="/zoo" />);
+                    const props = this.baseLinkSpy.getCall(0).args[0];
+                    expect(props.to).to.equal(`/zoo${queryString}`);
+                });
+                it(`resolves to "/zoo${queryString}" when given "/zoo/"`, () => {
+                    mount(<Component currentPath={this.currentPath} to="/zoo/" />);
+                    const props = this.baseLinkSpy.getCall(0).args[0];
+                    expect(props.to).to.equal(`/zoo${queryString}`);
+                });
+                it(`resolves to "/zoo${queryString}" when given "zoo/"`, () => {
+                    mount(<Component currentPath={this.currentPath} to="zoo/" />);
+                    const props = this.baseLinkSpy.getCall(0).args[0];
+                    expect(props.to).to.equal(`/zoo${queryString}`);
+                });
             });
-            afterEach(() => {
-                this.baseLinkSpy.restore();
+
+            describe("when the current path is not specified", function() {
+                beforeEach(() => {
+                    this.baseLinkSpy = sinon.spy(Component, "BaseComponent");
+                    global.location.hash = `#/foo${queryString}`;
+                });
+                afterEach(() => {
+                    this.baseLinkSpy.restore();
+                });
+                it("used window.location.hash to resolve", () => {
+                    mount(<Component to="bar"/>);
+                    const props = this.baseLinkSpy.getCall(0).args[0];
+                    expect(props.to).to.equal(`/foo/bar${queryString}`);
+                });
             });
-            it("used window.location.hash to resolve", () => {
-                mount(<Component to="bar"/>);
-                const props = this.baseLinkSpy.getCall(0).args[0];
-                expect(props.to).to.equal("/foo/bar");
-            });
-        });
-        describe("when changing props", function() {
-            beforeEach(() => {
-                this.baseLinkSpy = sinon.spy(Component, "BaseComponent");
-                this.currentPath = "/foo";
-            });
-            afterEach(() => {
-                this.baseLinkSpy.restore();
-            });
-            it("respects the new value of `currentPath`", () => {
-                const wrapper = mount(<Component currentPath={this.currentPath} to="bar" />);
-                wrapper.setProps({ currentPath:"/baz", to:"bar"});
-                const props = this.baseLinkSpy.getCall(0).args[0];
-                expect(props.to).to.equal("/foo/bar");
+            describe("when changing props", function() {
+                beforeEach(() => {
+                    this.baseLinkSpy = sinon.spy(Component, "BaseComponent");
+                    this.currentPath = `/foo${queryString}`;
+                });
+                afterEach(() => {
+                    this.baseLinkSpy.restore();
+                });
+                it("respects the new value of `currentPath`", () => {
+                    const wrapper = mount(<Component currentPath={this.currentPath} to="bar" />);
+                    wrapper.setProps({ currentPath:"/baz", to:"bar"});
+                    const props = this.baseLinkSpy.getCall(0).args[0];
+                    expect(props.to).to.equal(`/foo/bar${queryString}`);
+                });
             });
         });
     });


### PR DESCRIPTION
Before appending a relative query to the current location, remove the query string, then add it again.